### PR TITLE
fea: oxc fmt & lint

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "ignorePatterns": []
+}

--- a/.oxlintignore
+++ b/.oxlintignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+dist
+coverage
+generated
+*.tsbuildinfo
+pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # Farming Labs ORM
- 
-
 
 ## Workspace
 

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "demo",
-  "private": true,
   "version": "0.0.0",
+  "private": true,
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit",

--- a/apps/docs/app/docs/layout.tsx
+++ b/apps/docs/app/docs/layout.tsx
@@ -1,15 +1,10 @@
 import docsConfig from "../../docs.config";
-import {
-  createNextDocsLayout,
-  createNextDocsMetadata,
-} from "@farming-labs/next/layout";
+import { createNextDocsLayout, createNextDocsMetadata } from "@farming-labs/next/layout";
 
 export const metadata = createNextDocsMetadata(docsConfig);
 
 const DocsLayout = createNextDocsLayout(docsConfig);
 
-export default function Layout({
-  children,
-}: Readonly<{ children: React.ReactNode }>) {
+export default function Layout({ children }: Readonly<{ children: React.ReactNode }>) {
   return <DocsLayout>{children}</DocsLayout>;
 }

--- a/apps/docs/app/docs/page.mdx
+++ b/apps/docs/app/docs/page.mdx
@@ -51,7 +51,9 @@ order: 1
   </article>
   <article className="docs-overview-stat">
     <strong>1 consistent docs system</strong>
-    <p>The docs route stays on <code>@farming-labs/docs</code> with the pixel-border theme.</p>
+    <p>
+      The docs route stays on <code>@farming-labs/docs</code> with the pixel-border theme.
+    </p>
   </article>
 </div>
 
@@ -70,7 +72,10 @@ order: 1
   </a>
   <a className="docs-overview-link" href="/docs/cli">
     <strong>CLI generation</strong>
-    <p>Understand how the CLI loads <code>@farming-labs/orm</code> schemas directly and writes target-specific output.</p>
+    <p>
+      Understand how the CLI loads <code>@farming-labs/orm</code> schemas directly and writes
+      target-specific output.
+    </p>
     <span>Open section</span>
   </a>
   <a className="docs-overview-link" href="/docs/use-cases">
@@ -85,27 +90,36 @@ order: 1
 <div className="docs-overview-uses not-prose">
   <article className="docs-overview-use">
     <strong>Auth systems</strong>
-    <p>Replace one Prisma adapter, one Drizzle adapter, and one Kysely adapter with a single schema contract and targeted outputs.</p>
+    <p>
+      Replace one Prisma adapter, one Drizzle adapter, and one Kysely adapter with a single schema
+      contract and targeted outputs.
+    </p>
   </article>
   <article className="docs-overview-use">
     <strong>Reusable product kits</strong>
-    <p>Ship storage-aware packages for billing, organizations, permissions, and audit logs without dictating the consumer’s ORM.</p>
+    <p>
+      Ship storage-aware packages for billing, organizations, permissions, and audit logs without
+      dictating the consumer’s ORM.
+    </p>
   </article>
   <article className="docs-overview-use">
     <strong>Internal platforms</strong>
-    <p>Keep shared domain models stable across multiple apps and services while generating the local integration layer each team needs.</p>
+    <p>
+      Keep shared domain models stable across multiple apps and services while generating the local
+      integration layer each team needs.
+    </p>
   </article>
 </div>
 
 ## What ships today
 
-| Layer | Status | Notes |
-| --- | --- | --- |
-| `@farming-labs/orm` | Live | Schema DSL, manifest, generators, typed helpers, memory runtime |
-| `@farming-labs/orm-cli` | Live | Loads schemas directly and generates target artifacts |
-| Prisma generation | Live | PostgreSQL, MySQL, and SQLite providers |
-| Drizzle generation | Live | `pg`, `mysql`, and `sqlite` dialects |
-| Safe SQL generation | Live | Forward-safe SQL output for PostgreSQL, MySQL, and SQLite |
+| Layer                   | Status  | Notes                                                                 |
+| ----------------------- | ------- | --------------------------------------------------------------------- |
+| `@farming-labs/orm`     | Live    | Schema DSL, manifest, generators, typed helpers, memory runtime       |
+| `@farming-labs/orm-cli` | Live    | Loads schemas directly and generates target artifacts                 |
+| Prisma generation       | Live    | PostgreSQL, MySQL, and SQLite providers                               |
+| Drizzle generation      | Live    | `pg`, `mysql`, and `sqlite` dialects                                  |
+| Safe SQL generation     | Live    | Forward-safe SQL output for PostgreSQL, MySQL, and SQLite             |
 | Runtime driver packages | Planned | Prisma, Drizzle, Kysely, SQL, and Mongoose packages can layer on next |
 
 ## Why this docs route uses `@farming-labs/docs`

--- a/apps/docs/app/docs/schema/page.mdx
+++ b/apps/docs/app/docs/schema/page.mdx
@@ -27,7 +27,7 @@ user: model({
   relations: {
     sessions: hasMany("session", { foreignKey: "userId" }),
   },
-})
+});
 ```
 
 ## Why this matters

--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -74,8 +74,7 @@ a {
   position: relative;
   background:
     radial-gradient(circle at top center, rgba(125, 211, 252, 0.08), transparent 24%),
-    radial-gradient(circle at 18% 12%, rgba(255, 255, 255, 0.05), transparent 22%),
-    #050505;
+    radial-gradient(circle at 18% 12%, rgba(255, 255, 255, 0.05), transparent 22%), #050505;
 }
 
 #nd-docs-layout::before {
@@ -97,8 +96,7 @@ a {
 }
 
 #nd-sidebar {
-  background:
-    linear-gradient(180deg, rgba(12, 12, 13, 0.96), rgba(7, 7, 8, 0.94)) !important;
+  background: linear-gradient(180deg, rgba(12, 12, 13, 0.96), rgba(7, 7, 8, 0.94)) !important;
   border-color: rgba(255, 255, 255, 0.08) !important;
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.04),

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -20,9 +20,7 @@ export const metadata: Metadata = {
     "Unified schema, typed runtime, and generator-first tooling for Prisma, Drizzle, and safe SQL.",
 };
 
-export default function RootLayout({
-  children,
-}: Readonly<{ children: React.ReactNode }>) {
+export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en" className="dark" suppressHydrationWarning>
       <body className={`${heading.className} ${heading.variable} ${mono.variable}`}>

--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -15,11 +15,9 @@ const sectionTopRule =
 const btnBase =
   "inline-flex min-h-[46px] items-center justify-center rounded-none px-[18px] font-bold transition duration-150 ease-out hover:-translate-y-px max-md:w-full";
 
-const btnPrimary =
-  `${btnBase} border border-dashed border-white/[0.22] bg-white/[0.06] text-slate-50 shadow-none`;
+const btnPrimary = `${btnBase} border border-dashed border-white/[0.22] bg-white/[0.06] text-slate-50 shadow-none`;
 
-const btnSecondary =
-  `${btnBase} border border-white/10 bg-white/[0.03] text-slate-100`;
+const btnSecondary = `${btnBase} border border-white/10 bg-white/[0.03] text-slate-100`;
 
 const toneBorder: Record<string, string> = {
   cyan: "border-dashed border-sky-300/30",
@@ -111,11 +109,9 @@ const sectionTitle =
 
 const sectionText = "m-0 leading-[1.8] text-slate-300/80";
 
-const cardLabel =
-  "font-mono text-[0.76rem] uppercase tracking-[0.06em] text-slate-200";
+const cardLabel = "font-mono text-[0.76rem] uppercase tracking-[0.06em] text-slate-200";
 
-const heading3 =
-  "my-2.5 text-xl font-normal leading-snug tracking-tight first:mt-0";
+const heading3 = "my-2.5 text-xl font-normal leading-snug tracking-tight first:mt-0";
 
 export default function HomePage() {
   return (
@@ -157,8 +153,8 @@ export default function HomePage() {
               />
             </h1>
             <p className="font-mono text-lg font-light uppercase tracking-tight text-white/70">
-              Define the data model once, then generate the storage layer each
-              app stack wants along with built-in cli.
+              Define the data model once, then generate the storage layer each app stack wants along
+              with built-in cli.
             </p>
 
             <div className="flex flex-wrap items-center gap-3">
@@ -234,22 +230,17 @@ export default function HomePage() {
       <section id="platform" className={cn(sectionShell, sectionTopRule)}>
         <div className="grid max-w-[840px] gap-4">
           <span className={kicker}>Platform</span>
-          <h2 className={sectionTitle}>
-            Built as a system, not a pile of storage-specific glue.
-          </h2>
+          <h2 className={sectionTitle}>Built as a system, not a pile of storage-specific glue.</h2>
           <p className={sectionText}>
-            The point is not to hide complexity with magic. It is to centralize
-            the real shared contract so generation, docs, examples, and future
-            drivers all line up around the same data model.
+            The point is not to hide complexity with magic. It is to centralize the real shared
+            contract so generation, docs, examples, and future drivers all line up around the same
+            data model.
           </p>
         </div>
 
         <div className="grid w-full grid-cols-3 gap-[18px] max-lg:grid-cols-1">
           {platformCards.map((card) => (
-            <article
-              key={card.title}
-              className={cn(panel, "p-6", toneBorder[card.tone])}
-            >
+            <article key={card.title} className={cn(panel, "p-6", toneBorder[card.tone])}>
               <span className={cardLabel}>{card.label}</span>
               <h3 className={heading3}>{card.title}</h3>
               <p className={sectionText}>{card.body}</p>
@@ -265,9 +256,9 @@ export default function HomePage() {
             A modern product surface for teams shipping reusable packages.
           </h2>
           <p className={sectionText}>
-            This works especially well when your package has to meet Prisma
-            users, Drizzle users, SQL-first teams, and documentation readers
-            without rewriting the same story over and over.
+            This works especially well when your package has to meet Prisma users, Drizzle users,
+            SQL-first teams, and documentation readers without rewriting the same story over and
+            over.
           </p>
         </div>
 
@@ -312,13 +303,11 @@ export default function HomePage() {
         <div className="grid max-w-[840px] gap-4">
           <span className={kicker}>Use cases</span>
           <h2 className={sectionTitle}>
-            A better fit for auth, billing, and platform libraries than ORM-by-ORM
-            adapters.
+            A better fit for auth, billing, and platform libraries than ORM-by-ORM adapters.
           </h2>
           <p className={sectionText}>
-            Reusable packages need a stable storage-facing contract. This is the
-            kind of system that keeps that contract intact while still meeting the
-            integration needs of downstream apps.
+            Reusable packages need a stable storage-facing contract. This is the kind of system that
+            keeps that contract intact while still meeting the integration needs of downstream apps.
           </p>
         </div>
 
@@ -339,9 +328,8 @@ export default function HomePage() {
             Sharp visuals, but still honest about the current implementation.
           </h2>
           <p className={sectionText}>
-            The project can look polished without pretending every runtime package
-            is already done. The landing page should sell the direction while still
-            telling the truth.
+            The project can look polished without pretending every runtime package is already done.
+            The landing page should sell the direction while still telling the truth.
           </p>
         </div>
 
@@ -352,9 +340,7 @@ export default function HomePage() {
               className="flex items-center justify-between gap-[22px] border-b border-white/[0.08] p-6 last:border-b-0 max-md:flex-col max-md:items-start"
             >
               <div>
-                <strong className="mb-1.5 block text-base font-semibold">
-                  {row.label}
-                </strong>
+                <strong className="mb-1.5 block text-base font-semibold">{row.label}</strong>
                 <p className={sectionText}>{row.value}</p>
               </div>
               <span
@@ -381,13 +367,12 @@ export default function HomePage() {
         <div className="grid gap-4">
           <span className={kicker}>Next step</span>
           <h2 className={sectionTitle}>
-            Follow the docs route and the example workflow that this monorepo is
-            already testing.
+            Follow the docs route and the example workflow that this monorepo is already testing.
           </h2>
           <p className={sectionText}>
-            The homepage sets the tone, then <code className="text-slate-200">/docs</code> carries the
-            product forward with `@farming-labs/docs`, the pixel-border theme, and
-            the actual generator story underneath.
+            The homepage sets the tone, then <code className="text-slate-200">/docs</code> carries
+            the product forward with `@farming-labs/docs`, the pixel-border theme, and the actual
+            generator story underneath.
           </p>
         </div>
 

--- a/apps/docs/components/ui/beam-background.tsx
+++ b/apps/docs/components/ui/beam-background.tsx
@@ -1,19 +1,7 @@
 "use client";
 
-import {
-  forwardRef,
-  useEffect,
-  useImperativeHandle,
-  useMemo,
-  useRef,
-  type ReactNode,
-} from "react";
-import {
-  Canvas,
-  useFrame,
-  useThree,
-  type ThreeElements,
-} from "@react-three/fiber";
+import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, type ReactNode } from "react";
+import { Canvas, useFrame, useThree, type ThreeElements } from "@react-three/fiber";
 import { Environment, PerspectiveCamera } from "@react-three/drei";
 import * as THREE from "three";
 
@@ -86,19 +74,12 @@ float cnoise(vec3 P){
 }`;
 
 const extendMaterial = (
-  BaseMaterial: new (
-    params?: THREE.MeshStandardMaterialParameters,
-  ) => THREE.MeshStandardMaterial,
+  BaseMaterial: new (params?: THREE.MeshStandardMaterialParameters) => THREE.MeshStandardMaterial,
   cfg: MaterialConfig,
 ) => {
   const physical = THREE.ShaderLib.physical;
-  const {
-    vertexShader: baseVert,
-    fragmentShader: baseFrag,
-    uniforms: baseUniforms,
-  } = physical;
-  const baseDefines =
-    (physical as { defines?: Record<string, unknown> }).defines ?? {};
+  const { vertexShader: baseVert, fragmentShader: baseFrag, uniforms: baseUniforms } = physical;
+  const baseDefines = (physical as { defines?: Record<string, unknown> }).defines ?? {};
   const uniforms = THREE.UniformsUtils.clone(baseUniforms);
   const defaults = new BaseMaterial(cfg.material || {});
 
@@ -112,9 +93,7 @@ const extendMaterial = (
 
   for (const [key, uniformValue] of Object.entries(cfg.uniforms ?? {})) {
     uniforms[key] =
-      uniformValue !== null &&
-      typeof uniformValue === "object" &&
-      "value" in uniformValue
+      uniformValue !== null && typeof uniformValue === "object" && "value" in uniformValue
         ? (uniformValue as THREE.IUniform)
         : { value: uniformValue };
   }
@@ -181,10 +160,7 @@ const createStackedPlanesBufferGeometry = (
       positions.set([...v0, ...v1], vertexOffset * 3);
 
       const uvY = segmentIndex / heightSegments;
-      uvs.set(
-        [uvXOffset, uvY + uvYOffset, uvXOffset + 1, uvY + uvYOffset],
-        uvOffset,
-      );
+      uvs.set([uvXOffset, uvY + uvYOffset, uvXOffset + 1, uvY + uvYOffset], uvOffset);
 
       if (segmentIndex < heightSegments) {
         const a = vertexOffset;
@@ -208,18 +184,12 @@ const createStackedPlanesBufferGeometry = (
 };
 
 const CanvasWrapper = ({ children }: { children: ReactNode }) => (
-  <Canvas
-    dpr={[1, 2]}
-    frameloop="always"
-    className="absolute inset-0 h-full w-full"
-  >
+  <Canvas dpr={[1, 2]} frameloop="always" className="absolute inset-0 h-full w-full">
     {children}
   </Canvas>
 );
 
-const DirectionalBeamLight = (
-  props: ThreeElements["directionalLight"] & { color: string },
-) => {
+const DirectionalBeamLight = (props: ThreeElements["directionalLight"] & { color: string }) => {
   const lightRef = useRef<THREE.DirectionalLight>(null!);
 
   useEffect(() => {
@@ -244,9 +214,7 @@ interface NoisePlanesProps {
 
 const NoisePlanes = forwardRef<THREE.Mesh, NoisePlanesProps>(
   ({ material, width, count, height }, ref) => {
-    const meshRef = useRef<
-      THREE.Mesh<THREE.BufferGeometry, THREE.ShaderMaterial> | null
-    >(null);
+    const meshRef = useRef<THREE.Mesh<THREE.BufferGeometry, THREE.ShaderMaterial> | null>(null);
 
     useImperativeHandle(ref, () => meshRef.current as THREE.Mesh);
 
@@ -260,14 +228,7 @@ const NoisePlanes = forwardRef<THREE.Mesh, NoisePlanesProps>(
       meshRef.current.material.uniforms.time.value += 0.1 * delta;
     });
 
-    return (
-      <mesh
-        ref={meshRef}
-        geometry={geometry}
-        material={material}
-        position={[0, 0, 0]}
-      />
-    );
+    return <mesh ref={meshRef} geometry={geometry} material={material} position={[0, 0, 0]} />;
   },
 );
 
@@ -352,10 +313,8 @@ export default function BeamBackground({
             return normalize(cross(tangentZ, tangentX));
           }`,
         vertex: {
-          "#include <begin_vertex>":
-            "transformed.z += getPos(transformed.xyz);",
-          "#include <beginnormal_vertex>":
-            "objectNormal = getNormal(position.xyz);",
+          "#include <begin_vertex>": "transformed.z += getPos(transformed.xyz);",
+          "#include <beginnormal_vertex>": "objectNormal = getNormal(position.xyz);",
         },
         fragment: {
           "#include <dithering_fragment>": `
@@ -381,10 +340,7 @@ export default function BeamBackground({
     <div className="absolute inset-0 opacity-25">
       <CanvasWrapper>
         <MouseInteraction>
-          <group
-            rotation={[0, 0, THREE.MathUtils.degToRad(rotation)]}
-            position={[0, 0, 0]}
-          >
+          <group rotation={[0, 0, THREE.MathUtils.degToRad(rotation)]} position={[0, 0, 0]}>
             <NoisePlanes
               material={beamMaterial}
               count={validBeamNumber}

--- a/apps/docs/docs.config.tsx
+++ b/apps/docs/docs.config.tsx
@@ -54,8 +54,8 @@ export default defineDocs({
       <div className="docs-sidebar-banner">
         <strong>Source of truth</strong>
         <p>
-          Define the schema once in <code>@farming-labs/orm</code>, then let
-          generation and docs orbit the same contract.
+          Define the schema once in <code>@farming-labs/orm</code>, then let generation and docs
+          orbit the same contract.
         </p>
       </div>
     ),

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docs",
-  "private": true,
   "version": "0.0.0",
+  "private": true,
   "scripts": {
     "build": "next build",
     "dev": "next dev",

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -6,9 +6,7 @@
     "allowJs": false,
     "incremental": true,
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"]
     },
     "plugins": [
       {
@@ -18,13 +16,6 @@
     "noEmit": true,
     "isolatedModules": true
   },
-  "include": [
-    "**/*.ts",
-    "**/*.tsx",
-    "**/*.mdx",
-    ".next/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["**/*.ts", "**/*.tsx", "**/*.mdx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }

--- a/package.json
+++ b/package.json
@@ -1,20 +1,27 @@
 {
   "name": "farming-labs-orm",
-  "private": true,
   "version": "0.0.0",
-  "packageManager": "pnpm@10.9.0",
+  "private": true,
   "scripts": {
     "build": "pnpm -r build",
     "dev:docs": "pnpm --filter docs dev",
     "dev:demo": "pnpm --filter demo dev",
     "test": "pnpm -r test && pnpm test:e2e",
     "test:e2e": "vitest run tests/e2e.test.ts",
-    "typecheck": "pnpm -r typecheck"
+    "typecheck": "pnpm -r typecheck",
+    "lint": "oxlint . --ignore-path .oxlintignore",
+    "lint:fix": "oxlint --fix . --ignore-path .oxlintignore",
+    "fmt": "oxfmt .",
+    "fmt:check": "oxfmt --check .",
+    "check": "pnpm lint && pnpm fmt:check && pnpm typecheck"
   },
   "devDependencies": {
     "@types/node": "^22.13.10",
+    "oxfmt": "^0.41.0",
+    "oxlint": "^1.56.0",
     "tsx": "^4.19.3",
     "typescript": "^5.8.2",
     "vitest": "^3.1.1"
-  }
+  },
+  "packageManager": "pnpm@10.9.0"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,13 +1,16 @@
 {
   "name": "@farming-labs/orm-cli",
   "version": "0.1.0",
+  "bin": {
+    "farm-orm": "./dist/bin.js"
+  },
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "bin": {
-    "farm-orm": "./dist/bin.js"
-  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -15,9 +18,6 @@
       "require": "./dist/index.cjs"
     }
   },
-  "files": [
-    "dist"
-  ],
   "scripts": {
     "build": "tsx ./scripts/build.ts",
     "test": "pnpm --filter @farming-labs/orm build && vitest run",

--- a/packages/cli/scripts/build.ts
+++ b/packages/cli/scripts/build.ts
@@ -6,5 +6,5 @@ await build({
   format: ["esm", "cjs"],
   sourcemap: true,
   clean: true,
-  outDir: "dist"
+  outDir: "dist",
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -71,10 +71,7 @@ async function readIfExists(filePath: string) {
   return readFile(filePath, "utf8");
 }
 
-export async function generateTarget(
-  target: keyof FarmOrmConfig["targets"],
-  configPath?: string,
-) {
+export async function generateTarget(target: keyof FarmOrmConfig["targets"], configPath?: string) {
   const { config } = await loadConfig(configPath);
   const schema = mergeSchemas(config.schemas);
 
@@ -107,11 +104,7 @@ export async function generateTarget(
     }
     const outputPath = path.resolve(process.cwd(), targetConfig.out);
     await ensureFileDirectory(outputPath);
-    await writeFile(
-      outputPath,
-      renderDrizzleSchema(schema, targetConfig),
-      "utf8",
-    );
+    await writeFile(outputPath, renderDrizzleSchema(schema, targetConfig), "utf8");
     return outputPath;
   }
 
@@ -125,10 +118,7 @@ export async function generateTarget(
   return outputPath;
 }
 
-export async function checkTarget(
-  target: keyof FarmOrmConfig["targets"],
-  configPath?: string,
-) {
+export async function checkTarget(target: keyof FarmOrmConfig["targets"], configPath?: string) {
   const { config } = await loadConfig(configPath);
   const schema = mergeSchemas(config.schemas);
 

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@farming-labs/orm",
   "version": "0.1.0",
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -12,9 +15,6 @@
       "require": "./dist/index.cjs"
     }
   },
-  "files": [
-    "dist"
-  ],
   "scripts": {
     "build": "tsx ./scripts/build.ts",
     "test": "vitest run",

--- a/packages/orm/scripts/build.ts
+++ b/packages/orm/scripts/build.ts
@@ -6,5 +6,5 @@ await build({
   format: ["esm", "cjs"],
   sourcemap: true,
   clean: true,
-  outDir: "dist"
+  outDir: "dist",
 });

--- a/packages/orm/src/client.ts
+++ b/packages/orm/src/client.ts
@@ -1,7 +1,6 @@
 import type { SchemaDefinition } from "./schema";
 import type {
   ModelName,
-  ModelRelations,
   RelationForName,
   RelationName,
   RelationTarget,
@@ -28,10 +27,7 @@ export type Where<TRecord extends Record<string, Primitive>> = {
   NOT?: Where<TRecord>;
 };
 
-type RelationQuery<
-  TSchema extends SchemaDefinition<any>,
-  TModelName extends ModelName<TSchema>
-> = {
+type RelationQuery<TSchema extends SchemaDefinition<any>, TModelName extends ModelName<TSchema>> = {
   where?: Where<ScalarRecord<TSchema, TModelName>>;
   select?: SelectShape<TSchema, TModelName>;
   orderBy?: Partial<Record<keyof ScalarRecord<TSchema, TModelName> & string, Direction>>;
@@ -42,12 +38,12 @@ type RelationQuery<
 type RelationSelectionValue<
   TSchema extends SchemaDefinition<any>,
   TModelName extends ModelName<TSchema>,
-  TRelationName extends RelationName<TSchema, TModelName>
+  TRelationName extends RelationName<TSchema, TModelName>,
 > = true | RelationQuery<TSchema, RelationTarget<TSchema, TModelName, TRelationName>>;
 
 export type SelectShape<
   TSchema extends SchemaDefinition<any>,
-  TModelName extends ModelName<TSchema>
+  TModelName extends ModelName<TSchema>,
 > = {
   [K in
     | (keyof ScalarRecord<TSchema, TModelName> & string)
@@ -62,13 +58,13 @@ type IsManyRelation<TRelation> = TRelation extends { kind: "hasMany" | "manyToMa
 
 type DefaultSelectedRecord<
   TSchema extends SchemaDefinition<any>,
-  TModelName extends ModelName<TSchema>
+  TModelName extends ModelName<TSchema>,
 > = ScalarRecord<TSchema, TModelName>;
 
 type SelectedScalars<
   TSchema extends SchemaDefinition<any>,
   TModelName extends ModelName<TSchema>,
-  TSelect extends SelectShape<TSchema, TModelName>
+  TSelect extends SelectShape<TSchema, TModelName>,
 > = {
   [K in keyof TSelect & keyof ScalarRecord<TSchema, TModelName> as TSelect[K] extends true
     ? K
@@ -79,7 +75,7 @@ type RelationResult<
   TSchema extends SchemaDefinition<any>,
   TModelName extends ModelName<TSchema>,
   TRelationName extends RelationName<TSchema, TModelName>,
-  TValue extends RelationSelectionValue<TSchema, TModelName, TRelationName>
+  TValue extends RelationSelectionValue<TSchema, TModelName, TRelationName>,
 > = TValue extends true
   ? IsManyRelation<RelationForName<TSchema, TModelName, TRelationName>> extends true
     ? Array<DefaultSelectedRecord<TSchema, RelationTarget<TSchema, TModelName, TRelationName>>>
@@ -91,26 +87,21 @@ type RelationResult<
             SelectedRecord<
               TSchema,
               Target,
-              TValue["select"] extends SelectShape<TSchema, Target>
-                ? TValue["select"]
-                : undefined
+              TValue["select"] extends SelectShape<TSchema, Target> ? TValue["select"] : undefined
             >
           >
-        : | SelectedRecord<
-              TSchema,
-              Target,
-              TValue["select"] extends SelectShape<TSchema, Target>
-                ? TValue["select"]
-                : undefined
-            >
-          | null
+        : SelectedRecord<
+            TSchema,
+            Target,
+            TValue["select"] extends SelectShape<TSchema, Target> ? TValue["select"] : undefined
+          > | null
       : never
     : never;
 
 type SelectedRelations<
   TSchema extends SchemaDefinition<any>,
   TModelName extends ModelName<TSchema>,
-  TSelect extends SelectShape<TSchema, TModelName>
+  TSelect extends SelectShape<TSchema, TModelName>,
 > = {
   [K in keyof TSelect & RelationName<TSchema, TModelName>]: RelationResult<
     TSchema,
@@ -123,16 +114,17 @@ type SelectedRelations<
 export type SelectedRecord<
   TSchema extends SchemaDefinition<any>,
   TModelName extends ModelName<TSchema>,
-  TSelect extends SelectShape<TSchema, TModelName> | undefined
-> = TSelect extends SelectShape<TSchema, TModelName>
-  ? SelectedScalars<TSchema, TModelName, TSelect> &
-      SelectedRelations<TSchema, TModelName, TSelect>
-  : DefaultSelectedRecord<TSchema, TModelName>;
+  TSelect extends SelectShape<TSchema, TModelName> | undefined,
+> =
+  TSelect extends SelectShape<TSchema, TModelName>
+    ? SelectedScalars<TSchema, TModelName, TSelect> &
+        SelectedRelations<TSchema, TModelName, TSelect>
+    : DefaultSelectedRecord<TSchema, TModelName>;
 
 export type FindManyArgs<
   TSchema extends SchemaDefinition<any>,
   TModelName extends ModelName<TSchema>,
-  TSelect extends SelectShape<TSchema, TModelName> | undefined = undefined
+  TSelect extends SelectShape<TSchema, TModelName> | undefined = undefined,
 > = {
   where?: Where<ScalarRecord<TSchema, TModelName>>;
   select?: TSelect;
@@ -144,13 +136,13 @@ export type FindManyArgs<
 export type FindFirstArgs<
   TSchema extends SchemaDefinition<any>,
   TModelName extends ModelName<TSchema>,
-  TSelect extends SelectShape<TSchema, TModelName> | undefined = undefined
+  TSelect extends SelectShape<TSchema, TModelName> | undefined = undefined,
 > = FindManyArgs<TSchema, TModelName, TSelect>;
 
 export type CreateArgs<
   TSchema extends SchemaDefinition<any>,
   TModelName extends ModelName<TSchema>,
-  TSelect extends SelectShape<TSchema, TModelName> | undefined = undefined
+  TSelect extends SelectShape<TSchema, TModelName> | undefined = undefined,
 > = {
   data: Partial<ScalarRecord<TSchema, TModelName>>;
   select?: TSelect;
@@ -159,7 +151,7 @@ export type CreateArgs<
 export type UpdateArgs<
   TSchema extends SchemaDefinition<any>,
   TModelName extends ModelName<TSchema>,
-  TSelect extends SelectShape<TSchema, TModelName> | undefined = undefined
+  TSelect extends SelectShape<TSchema, TModelName> | undefined = undefined,
 > = {
   where: Where<ScalarRecord<TSchema, TModelName>>;
   data: Partial<ScalarRecord<TSchema, TModelName>>;
@@ -168,7 +160,7 @@ export type UpdateArgs<
 
 export type DeleteArgs<
   TSchema extends SchemaDefinition<any>,
-  TModelName extends ModelName<TSchema>
+  TModelName extends ModelName<TSchema>,
 > = {
   where: Where<ScalarRecord<TSchema, TModelName>>;
 };
@@ -176,7 +168,7 @@ export type DeleteArgs<
 export interface OrmDriver<TSchema extends SchemaDefinition<any>> {
   findMany<
     TModelName extends ModelName<TSchema>,
-    TSelect extends SelectShape<TSchema, TModelName> | undefined = undefined
+    TSelect extends SelectShape<TSchema, TModelName> | undefined = undefined,
   >(
     schema: TSchema,
     model: TModelName,
@@ -184,7 +176,7 @@ export interface OrmDriver<TSchema extends SchemaDefinition<any>> {
   ): Promise<Array<SelectedRecord<TSchema, TModelName, TSelect>>>;
   findFirst<
     TModelName extends ModelName<TSchema>,
-    TSelect extends SelectShape<TSchema, TModelName> | undefined = undefined
+    TSelect extends SelectShape<TSchema, TModelName> | undefined = undefined,
   >(
     schema: TSchema,
     model: TModelName,
@@ -192,7 +184,7 @@ export interface OrmDriver<TSchema extends SchemaDefinition<any>> {
   ): Promise<SelectedRecord<TSchema, TModelName, TSelect> | null>;
   create<
     TModelName extends ModelName<TSchema>,
-    TSelect extends SelectShape<TSchema, TModelName> | undefined = undefined
+    TSelect extends SelectShape<TSchema, TModelName> | undefined = undefined,
   >(
     schema: TSchema,
     model: TModelName,
@@ -200,7 +192,7 @@ export interface OrmDriver<TSchema extends SchemaDefinition<any>> {
   ): Promise<SelectedRecord<TSchema, TModelName, TSelect>>;
   update<
     TModelName extends ModelName<TSchema>,
-    TSelect extends SelectShape<TSchema, TModelName> | undefined = undefined
+    TSelect extends SelectShape<TSchema, TModelName> | undefined = undefined,
   >(
     schema: TSchema,
     model: TModelName,
@@ -219,7 +211,7 @@ export interface OrmDriver<TSchema extends SchemaDefinition<any>> {
 
 export type ModelClient<
   TSchema extends SchemaDefinition<any>,
-  TModelName extends ModelName<TSchema>
+  TModelName extends ModelName<TSchema>,
 > = {
   findMany<TSelect extends SelectShape<TSchema, TModelName> | undefined = undefined>(
     args?: FindManyArgs<TSchema, TModelName, TSelect>,
@@ -244,7 +236,7 @@ export type OrmClient<TSchema extends SchemaDefinition<any>> = {
 
 function createModelClient<
   TSchema extends SchemaDefinition<any>,
-  TModelName extends ModelName<TSchema>
+  TModelName extends ModelName<TSchema>,
 >(
   schema: TSchema,
   driver: OrmDriver<TSchema>,

--- a/packages/orm/src/fields.ts
+++ b/packages/orm/src/fields.ts
@@ -4,7 +4,7 @@ export type FieldReference = `${string}.${string}`;
 
 export type FieldConfig<
   Kind extends ScalarKind = ScalarKind,
-  Nullable extends boolean = boolean
+  Nullable extends boolean = boolean,
 > = {
   kind: Kind;
   nullable: Nullable;
@@ -18,17 +18,11 @@ export type FieldConfig<
 
 export type AnyFieldBuilder = FieldBuilder<ScalarKind, boolean>;
 
-const cloneField = <
-  Kind extends ScalarKind,
-  Nullable extends boolean = false
->(
+const cloneField = <Kind extends ScalarKind, Nullable extends boolean = false>(
   config: FieldConfig<Kind, Nullable>,
 ) => new FieldBuilder(config);
 
-export class FieldBuilder<
-  Kind extends ScalarKind,
-  Nullable extends boolean = false
-> {
+export class FieldBuilder<Kind extends ScalarKind, Nullable extends boolean = false> {
   readonly _tag = "field";
 
   constructor(readonly config: FieldConfig<Kind, Nullable>) {}
@@ -91,14 +85,12 @@ export type ScalarValue<Kind extends ScalarKind> = Kind extends "id"
       ? boolean
       : Date;
 
-export type FieldOutput<TField> = TField extends FieldBuilder<
-  infer Kind,
-  infer Nullable
->
-  ? Nullable extends true
-    ? ScalarValue<Kind> | null
-    : ScalarValue<Kind>
-  : never;
+export type FieldOutput<TField> =
+  TField extends FieldBuilder<infer Kind, infer Nullable>
+    ? Nullable extends true
+      ? ScalarValue<Kind> | null
+      : ScalarValue<Kind>
+    : never;
 
 export function id() {
   return new FieldBuilder({

--- a/packages/orm/src/generators.ts
+++ b/packages/orm/src/generators.ts
@@ -63,11 +63,7 @@ function drizzleImports(dialect: DrizzleGenerationOptions["dialect"], manifest: 
     ].filter(Boolean);
   }
 
-  return [
-    "sqliteTable",
-    "text",
-    "integer",
-  ];
+  return ["sqliteTable", "text", "integer"];
 }
 
 function drizzleColumn(field: ManifestField, dialect: DrizzleGenerationOptions["dialect"]) {
@@ -80,7 +76,10 @@ function drizzleColumn(field: ManifestField, dialect: DrizzleGenerationOptions["
 
   if (field.kind === "string") {
     if (dialect === "mysql") {
-      const base = field.unique || field.references ? `varchar("${field.column}", { length: 191 })` : `text("${field.column}")`;
+      const base =
+        field.unique || field.references
+          ? `varchar("${field.column}", { length: 191 })`
+          : `text("${field.column}")`;
       return `${base}${field.nullable ? "" : ".notNull()"}${field.unique ? ".unique()" : ""}${
         field.defaultValue !== undefined ? `.default(${JSON.stringify(field.defaultValue)})` : ""
       }`;
@@ -161,7 +160,7 @@ export function renderPrismaSchema(
       const fieldType = prismaType(field);
       const modifiers: string[] = [];
       if (field.kind === "id") modifiers.push("@id");
-      if (field.generated === "id") modifiers.push('@default(cuid())');
+      if (field.generated === "id") modifiers.push("@default(cuid())");
       if (field.generated === "now") modifiers.push("@default(now())");
       if (field.defaultValue !== undefined && field.generated === undefined) {
         modifiers.push(
@@ -197,10 +196,12 @@ export function renderPrismaSchema(
     return `model ${modelName} {\n${lines.join("\n")}${mapLine}\n}`;
   });
 
-  return `generator ${generatorName} {\n  provider = "prisma-client-js"\n}\n\n` +
+  return (
+    `generator ${generatorName} {\n  provider = "prisma-client-js"\n}\n\n` +
     `datasource ${datasourceName} {\n  provider = "${provider}"\n  url      = ${
       provider === "sqlite" ? '"file:./dev.db"' : 'env("DATABASE_URL")'
-    }\n}\n\n${blocks.join("\n\n")}\n`;
+    }\n}\n\n${blocks.join("\n\n")}\n`
+  );
 }
 
 export function renderDrizzleSchema(
@@ -269,11 +270,7 @@ export function renderSafeSql(schema: SchemaDefinition<any>, options: SqlGenerat
   return `${statements.join("\n\n")}\n`;
 }
 
-export function replaceGeneratedBlock(input: {
-  current: string;
-  label: string;
-  content: string;
-}) {
+export function replaceGeneratedBlock(input: { current: string; label: string; content: string }) {
   const start = `// @farming-labs/orm:start:${input.label}`;
   const end = `// @farming-labs/orm:end:${input.label}`;
   const block = `${start}\n${input.content.trim()}\n${end}`;

--- a/packages/orm/src/manifest.ts
+++ b/packages/orm/src/manifest.ts
@@ -27,39 +27,44 @@ export type SchemaManifest = {
 };
 
 export function createManifest<
-  TSchema extends SchemaDefinition<Record<string, AnyModelDefinition>>
+  TSchema extends SchemaDefinition<Record<string, AnyModelDefinition>>,
 >(schema: TSchema): SchemaManifest {
   const models = Object.fromEntries(
     (Object.entries(schema.models) as Array<[string, AnyModelDefinition]>).map(
       ([name, definition]) => {
-      const fields = Object.fromEntries(
-        (Object.entries(definition.fields) as Array<[string, AnyModelDefinition["fields"][string]]>).map(([fieldName, field]) => [
-          fieldName,
-          {
-            name: fieldName,
-            column: field.config.mappedName ?? fieldName,
-            kind: field.config.kind,
-            nullable: field.config.nullable,
-            unique: field.config.unique,
-            generated: field.config.generated,
-            defaultValue: field.config.defaultValue,
-            references: field.config.references,
-            description: field.config.description,
-          } satisfies ManifestField,
-        ]),
-      );
+        const fields = Object.fromEntries(
+          (
+            Object.entries(definition.fields) as Array<
+              [string, AnyModelDefinition["fields"][string]]
+            >
+          ).map(([fieldName, field]) => [
+            fieldName,
+            {
+              name: fieldName,
+              column: field.config.mappedName ?? fieldName,
+              kind: field.config.kind,
+              nullable: field.config.nullable,
+              unique: field.config.unique,
+              generated: field.config.generated,
+              defaultValue: field.config.defaultValue,
+              references: field.config.references,
+              description: field.config.description,
+            } satisfies ManifestField,
+          ]),
+        );
 
-      return [
-        name,
-        {
+        return [
           name,
-          table: definition.table,
-          description: definition.description,
-          fields,
-          relations: definition.relations,
-        } satisfies ManifestModel,
-      ];
-    }),
+          {
+            name,
+            table: definition.table,
+            description: definition.description,
+            fields,
+            relations: definition.relations,
+          } satisfies ManifestModel,
+        ];
+      },
+    ),
   );
 
   return { models };

--- a/packages/orm/src/memory.ts
+++ b/packages/orm/src/memory.ts
@@ -11,7 +11,7 @@ import type {
   Where,
 } from "./client";
 import type { SchemaDefinition } from "./schema";
-import type { ModelName, RelationName, ScalarRecord } from "./schema";
+import type { ModelName, RelationName } from "./schema";
 
 type MemoryStore<TSchema extends SchemaDefinition<any>> = Partial<
   Record<ModelName<TSchema>, Array<Record<string, unknown>>>
@@ -133,11 +133,7 @@ function sortRows(
   });
 }
 
-function pageRows(
-  rows: Array<Record<string, unknown>>,
-  skip?: number,
-  take?: number,
-) {
+function pageRows(rows: Array<Record<string, unknown>>, skip?: number, take?: number) {
   const start = skip ?? 0;
   const end = take === undefined ? undefined : start + take;
   return rows.slice(start, end);
@@ -156,19 +152,20 @@ export function createMemoryDriver<TSchema extends SchemaDefinition<any>>(
 
   function applyQuery<TModelName extends ModelName<TSchema>>(
     model: TModelName,
-    args:
-      | FindManyArgs<TSchema, TModelName, any>
-      | FindFirstArgs<TSchema, TModelName, any>,
+    args: FindManyArgs<TSchema, TModelName, any> | FindFirstArgs<TSchema, TModelName, any>,
   ) {
     const rows = getRows(model);
     const filtered = rows.filter((row) => matchesWhere(row, args.where));
-    const sorted = sortRows(filtered, args.orderBy as Partial<Record<string, "asc" | "desc">> | undefined);
+    const sorted = sortRows(
+      filtered,
+      args.orderBy as Partial<Record<string, "asc" | "desc">> | undefined,
+    );
     return pageRows(sorted, args.skip, args.take);
   }
 
   async function projectRow<
     TModelName extends ModelName<TSchema>,
-    TSelect extends SelectShape<TSchema, TModelName> | undefined
+    TSelect extends SelectShape<TSchema, TModelName> | undefined,
   >(
     schema: TSchema,
     model: TModelName,
@@ -209,7 +206,7 @@ export function createMemoryDriver<TSchema extends SchemaDefinition<any>>(
 
   async function resolveRelation<
     TModelName extends ModelName<TSchema>,
-    TRelationName extends RelationName<TSchema, TModelName>
+    TRelationName extends RelationName<TSchema, TModelName>,
   >(
     schema: TSchema,
     model: TModelName,
@@ -225,12 +222,7 @@ export function createMemoryDriver<TSchema extends SchemaDefinition<any>>(
       const foreignValue = row[relation.foreignKey];
       const target = targetRows.find((item) => item.id === foreignValue);
       return target
-        ? projectRow(
-            schema,
-            relation.target as ModelName<TSchema>,
-            target,
-            relationArgs.select,
-          )
+        ? projectRow(schema, relation.target as ModelName<TSchema>, target, relationArgs.select)
         : null;
     }
 
@@ -238,12 +230,7 @@ export function createMemoryDriver<TSchema extends SchemaDefinition<any>>(
       const targetRows = getRows(relation.target as ModelName<TSchema>);
       const target = targetRows.find((item) => item[relation.foreignKey] === row.id);
       return target
-        ? projectRow(
-            schema,
-            relation.target as ModelName<TSchema>,
-            target,
-            relationArgs.select,
-          )
+        ? projectRow(schema, relation.target as ModelName<TSchema>, target, relationArgs.select)
         : null;
     }
 
@@ -259,12 +246,7 @@ export function createMemoryDriver<TSchema extends SchemaDefinition<any>>(
       const filtered = paged.filter((item) => matchesWhere(item, relationArgs.where));
       return Promise.all(
         filtered.map((item) =>
-          projectRow(
-            schema,
-            relation.target as ModelName<TSchema>,
-            item,
-            relationArgs.select,
-          ),
+          projectRow(schema, relation.target as ModelName<TSchema>, item, relationArgs.select),
         ),
       );
     }
@@ -285,12 +267,7 @@ export function createMemoryDriver<TSchema extends SchemaDefinition<any>>(
 
     return Promise.all(
       filtered.map((item) =>
-        projectRow(
-          schema,
-          relation.target as ModelName<TSchema>,
-          item,
-          relationArgs.select,
-        ),
+        projectRow(schema, relation.target as ModelName<TSchema>, item, relationArgs.select),
       ),
     );
   }
@@ -302,9 +279,7 @@ export function createMemoryDriver<TSchema extends SchemaDefinition<any>>(
       args: FindManyArgs<TSchema, ModelName<TSchema>, any>,
     ) {
       const rows = applyQuery(model, args);
-      return Promise.all(
-        rows.map((row) => projectRow(schema, model, row, args.select)),
-      );
+      return Promise.all(rows.map((row) => projectRow(schema, model, row, args.select)));
     },
     async findFirst(
       schema: TSchema,

--- a/packages/orm/src/relations.ts
+++ b/packages/orm/src/relations.ts
@@ -2,7 +2,7 @@ export type RelationKind = "belongsTo" | "hasOne" | "hasMany" | "manyToMany";
 
 export type RelationDefinition<
   Target extends string = string,
-  Kind extends RelationKind = RelationKind
+  Kind extends RelationKind = RelationKind,
 > = Kind extends "manyToMany"
   ? {
       kind: Kind;
@@ -19,10 +19,7 @@ export type RelationDefinition<
 
 export type AnyRelation = RelationDefinition<string, RelationKind>;
 
-export function belongsTo<Target extends string>(
-  target: Target,
-  config: { foreignKey: string },
-) {
+export function belongsTo<Target extends string>(target: Target, config: { foreignKey: string }) {
   return {
     kind: "belongsTo",
     target,
@@ -30,10 +27,7 @@ export function belongsTo<Target extends string>(
   } satisfies RelationDefinition<Target, "belongsTo">;
 }
 
-export function hasOne<Target extends string>(
-  target: Target,
-  config: { foreignKey: string },
-) {
+export function hasOne<Target extends string>(target: Target, config: { foreignKey: string }) {
   return {
     kind: "hasOne",
     target,
@@ -41,10 +35,7 @@ export function hasOne<Target extends string>(
   } satisfies RelationDefinition<Target, "hasOne">;
 }
 
-export function hasMany<Target extends string>(
-  target: Target,
-  config: { foreignKey: string },
-) {
+export function hasMany<Target extends string>(target: Target, config: { foreignKey: string }) {
   return {
     kind: "hasMany",
     target,

--- a/packages/orm/src/schema.ts
+++ b/packages/orm/src/schema.ts
@@ -6,7 +6,7 @@ export type RelationMap = Record<string, AnyRelation>;
 
 export type ModelDefinition<
   Fields extends FieldMap = FieldMap,
-  Relations extends RelationMap = RelationMap
+  Relations extends RelationMap = RelationMap,
 > = {
   readonly _tag: "model";
   readonly table: string;
@@ -18,16 +18,13 @@ export type ModelDefinition<
 export type AnyModelDefinition = ModelDefinition<FieldMap, RelationMap>;
 
 export type SchemaDefinition<
-  Models extends Record<string, AnyModelDefinition> = Record<string, AnyModelDefinition>
+  Models extends Record<string, AnyModelDefinition> = Record<string, AnyModelDefinition>,
 > = {
   readonly _tag: "schema";
   readonly models: Models;
 };
 
-export function model<
-  Fields extends FieldMap,
-  Relations extends RelationMap = {}
->(config: {
+export function model<Fields extends FieldMap, Relations extends RelationMap = {}>(config: {
   table: string;
   fields: Fields;
   relations?: Relations;
@@ -42,63 +39,52 @@ export function model<
   };
 }
 
-export function defineSchema<
-  Models extends Record<string, AnyModelDefinition>
->(models: Models): SchemaDefinition<Models> {
+export function defineSchema<Models extends Record<string, AnyModelDefinition>>(
+  models: Models,
+): SchemaDefinition<Models> {
   return {
     _tag: "schema",
     models,
   };
 }
 
-export type SchemaModels<TSchema> = TSchema extends SchemaDefinition<infer Models>
-  ? Models
-  : never;
+export type SchemaModels<TSchema> = TSchema extends SchemaDefinition<infer Models> ? Models : never;
 
 export type ModelName<TSchema> = keyof SchemaModels<TSchema> & string;
 
-export type ModelForName<
-  TSchema,
-  TName extends ModelName<TSchema>
-> = SchemaModels<TSchema>[TName];
+export type ModelForName<TSchema, TName extends ModelName<TSchema>> = SchemaModels<TSchema>[TName];
 
-export type ModelFields<
+export type ModelFields<TSchema, TName extends ModelName<TSchema>> = ModelForName<
   TSchema,
-  TName extends ModelName<TSchema>
-> = ModelForName<TSchema, TName>["fields"];
+  TName
+>["fields"];
 
-export type ModelRelations<
+export type ModelRelations<TSchema, TName extends ModelName<TSchema>> = ModelForName<
   TSchema,
-  TName extends ModelName<TSchema>
-> = ModelForName<TSchema, TName>["relations"];
+  TName
+>["relations"];
 
-export type ScalarRecord<
-  TSchema,
-  TName extends ModelName<TSchema>
-> = {
-  [K in keyof ModelFields<TSchema, TName> & string]: FieldOutput<
-    ModelFields<TSchema, TName>[K]
-  >;
+export type ScalarRecord<TSchema, TName extends ModelName<TSchema>> = {
+  [K in keyof ModelFields<TSchema, TName> & string]: FieldOutput<ModelFields<TSchema, TName>[K]>;
 };
 
-export type RelationName<
+export type RelationName<TSchema, TName extends ModelName<TSchema>> = keyof ModelRelations<
   TSchema,
-  TName extends ModelName<TSchema>
-> = keyof ModelRelations<TSchema, TName> & string;
+  TName
+> &
+  string;
 
 export type RelationForName<
   TSchema,
   TName extends ModelName<TSchema>,
-  TRelationName extends RelationName<TSchema, TName>
+  TRelationName extends RelationName<TSchema, TName>,
 > = ModelRelations<TSchema, TName>[TRelationName];
 
 export type RelationTarget<
   TSchema,
   TName extends ModelName<TSchema>,
-  TRelationName extends RelationName<TSchema, TName>
-> = RelationForName<TSchema, TName, TRelationName> extends RelationDefinition<
-  infer Target,
-  any
->
-  ? Extract<Target, ModelName<TSchema>>
-  : never;
+  TRelationName extends RelationName<TSchema, TName>,
+> =
+  RelationForName<TSchema, TName, TRelationName> extends RelationDefinition<infer Target, any>
+    ? Extract<Target, ModelName<TSchema>>
+    : never;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@types/node':
         specifier: ^22.13.10
         version: 22.19.15
+      oxfmt:
+        specifier: ^0.41.0
+        version: 0.41.0
+      oxlint:
+        specifier: ^1.56.0
+        version: 1.56.0
       tsx:
         specifier: ^4.19.3
         version: 4.21.0
@@ -578,6 +584,234 @@ packages:
   '@orama/orama@3.1.18':
     resolution: {integrity: sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA==}
     engines: {node: '>= 20.0.0'}
+
+  '@oxfmt/binding-android-arm-eabi@0.41.0':
+    resolution: {integrity: sha512-REfrqeMKGkfMP+m/ScX4f5jJBSmVNYcpoDF8vP8f8eYPDuPGZmzp56NIUsYmx3h7f6NzC6cE3gqh8GDWrJHCKw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.41.0':
+    resolution: {integrity: sha512-s0b1dxNgb2KomspFV2LfogC2XtSJB42POXF4bMCLJyvQmAGos4ZtjGPfQreToQEaY0FQFjz3030ggI36rF1q5g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.41.0':
+    resolution: {integrity: sha512-EGXGualADbv/ZmamE7/2DbsrYmjoPlAmHEpTL4vapLF4EfVD6fr8/uQDFnPJkUBjiSWFJZtFNsGeN1B6V3owmA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.41.0':
+    resolution: {integrity: sha512-WxySJEvdQQYMmyvISH3qDpTvoS0ebnIP63IMxLLWowJyPp/AAH0hdWtlo+iGNK5y3eVfa5jZguwNaQkDKWpGSw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.41.0':
+    resolution: {integrity: sha512-Y2kzMkv3U3oyuYaR4wTfGjOTYTXiFC/hXmG0yVASKkbh02BJkvD98Ij8bIevr45hNZ0DmZEgqiXF+9buD4yMYQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.41.0':
+    resolution: {integrity: sha512-ptazDjdUyhket01IjPTT6ULS1KFuBfTUU97osTP96X5y/0oso+AgAaJzuH81oP0+XXyrWIHbRzozSAuQm4p48g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.41.0':
+    resolution: {integrity: sha512-UkoL2OKxFD+56bPEBcdGn+4juTW4HRv/T6w1dIDLnvKKWr6DbarB/mtHXlADKlFiJubJz8pRkttOR7qjYR6lTA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.41.0':
+    resolution: {integrity: sha512-gofu0PuumSOHYczD8p62CPY4UF6ee+rSLZJdUXkpwxg6pILiwSDBIouPskjF/5nF3A7QZTz2O9KFNkNxxFN9tA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-musl@0.41.0':
+    resolution: {integrity: sha512-VfVZxL0+6RU86T8F8vKiDBa+iHsr8PAjQmKGBzSCAX70b6x+UOMFl+2dNihmKmUwqkCazCPfYjt6SuAPOeQJ3g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.41.0':
+    resolution: {integrity: sha512-bwzokz2eGvdfJbc0i+zXMJ4BBjQPqg13jyWpEEZDOrBCQ91r8KeY2Mi2kUeuMTZNFXju+jcAbAbpyJxRGla0eg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.41.0':
+    resolution: {integrity: sha512-POLM//PCH9uqDeNDwWL3b3DkMmI3oI2cU6hwc2lnztD1o7dzrQs3R9nq555BZ6wI7t2lyhT9CS+CRaz5X0XqLA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.41.0':
+    resolution: {integrity: sha512-NNK7PzhFqLUwx/G12Xtm6scGv7UITvyGdAR5Y+TlqsG+essnuRWR4jRNODWRjzLZod0T3SayRbnkSIWMBov33w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.41.0':
+    resolution: {integrity: sha512-qVf/zDC5cN9eKe4qI/O/m445er1IRl6swsSl7jHkqmOSVfknwCe5JXitYjZca+V/cNJSU/xPlC5EFMabMMFDpw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxfmt/binding-linux-x64-gnu@0.41.0':
+    resolution: {integrity: sha512-ojxYWu7vUb6ysYqVCPHuAPVZHAI40gfZ0PDtZAMwVmh2f0V8ExpPIKoAKr7/8sNbAXJBBpZhs2coypIo2jJX4w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-x64-musl@0.41.0':
+    resolution: {integrity: sha512-O2exZLBxoCMIv2vlvcbkdedazJPTdG0VSup+0QUCfYQtx751zCZNboX2ZUOiQ/gDTdhtXvSiot0h6GEGkOyalA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxfmt/binding-openharmony-arm64@0.41.0':
+    resolution: {integrity: sha512-N+31/VoL+z+NNBt8viy3I4NaIdPbiYeOnB884LKqvXldaE2dRztdPv3q5ipfZYv0RwFp7JfqS4I27K/DSHCakg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.41.0':
+    resolution: {integrity: sha512-Z7NAtu/RN8kjCQ1y5oDD0nTAeRswh3GJ93qwcW51srmidP7XPBmZbLlwERu1W5veCevQJtPS9xmkpcDTYsGIwQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.41.0':
+    resolution: {integrity: sha512-uNxxP3l4bJ6VyzIeRqCmBU2Q0SkCFgIhvx9/9dJ9V8t/v+jP1IBsuaLwCXGR8JPHtkj4tFp+RHtUmU2ZYAUpMA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.41.0':
+    resolution: {integrity: sha512-49ZSpbZ1noozyPapE8SUOSm3IN0Ze4b5nkO+4+7fq6oEYQQJFhE0saj5k/Gg4oewVPdjn0L3ZFeWk2Vehjcw7A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint/binding-android-arm-eabi@1.56.0':
+    resolution: {integrity: sha512-IyfYPthZyiSKwAv/dLjeO18SaK8MxLI9Yss2JrRDyweQAkuL3LhEy7pwIwI7uA3KQc1Vdn20kdmj3q0oUIQL6A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.56.0':
+    resolution: {integrity: sha512-Ga5zYrzH6vc/VFxhn6MmyUnYEfy9vRpwTIks99mY3j6Nz30yYpIkWryI0QKPCgvGUtDSXVLEaMum5nA+WrNOSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.56.0':
+    resolution: {integrity: sha512-ogmbdJysnw/D4bDcpf1sPLpFThZ48lYp4aKYm10Z/6Nh1SON6NtnNhTNOlhEY296tDFItsZUz+2tgcSYqh8Eyw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.56.0':
+    resolution: {integrity: sha512-x8QE1h+RAtQ2g+3KPsP6Fk/tdz6zJQUv5c7fTrJxXV3GHOo+Ry5p/PsogU4U+iUZg0rj6hS+E4xi+mnwwlDCWQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.56.0':
+    resolution: {integrity: sha512-6G+WMZvwJpMvY7my+/SHEjb7BTk/PFbePqLpmVmUJRIsJMy/UlyYqjpuh0RCgYYkPLcnXm1rUM04kbTk8yS1Yg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.56.0':
+    resolution: {integrity: sha512-YYHBsk/sl7fYwQOok+6W5lBPeUEvisznV/HZD2IfZmF3Bns6cPC3Z0vCtSEOaAWTjYWN3jVsdu55jMxKlsdlhg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.56.0':
+    resolution: {integrity: sha512-+AZK8rOUr78y8WT6XkDb04IbMRqauNV+vgT6f8ZLOH8wnpQ9i7Nol0XLxAu+Cq7Sb+J9wC0j6Km5hG8rj47/yQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.56.0':
+    resolution: {integrity: sha512-urse2SnugwJRojUkGSSeH2LPMaje5Q50yQtvtL9HFckiyeqXzoFwOAZqD5TR29R2lq7UHidfFDM9EGcchcbb8A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-musl@1.56.0':
+    resolution: {integrity: sha512-rkTZkBfJ4TYLjansjSzL6mgZOdN5IvUnSq3oNJSLwBcNvy3dlgQtpHPrRxrCEbbcp7oQ6If0tkNaqfOsphYZ9g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.56.0':
+    resolution: {integrity: sha512-uqL1kMH3u69/e1CH2EJhP3CP28jw2ExLsku4o8RVAZ7fySo9zOyI2fy9pVlTAp4voBLVgzndXi3SgtdyCTa2aA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.56.0':
+    resolution: {integrity: sha512-j0CcMBOgV6KsRaBdsebIeiy7hCjEvq2KdEsiULf2LZqAq0v1M1lWjelhCV57LxsqaIGChXFuFJ0RiFrSRHPhSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxlint/binding-linux-riscv64-musl@1.56.0':
+    resolution: {integrity: sha512-7VDOiL8cDG3DQ/CY3yKjbV1c4YPvc4vH8qW09Vv+5ukq3l/Kcyr6XGCd5NvxUmxqDb2vjMpM+eW/4JrEEsUetA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxlint/binding-linux-s390x-gnu@1.56.0':
+    resolution: {integrity: sha512-JGRpX0M+ikD3WpwJ7vKcHKV6Kg0dT52BW2Eu2BupXotYeqGXBrbY+QPkAyKO6MNgKozyTNaRh3r7g+VWgyAQYQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxlint/binding-linux-x64-gnu@1.56.0':
+    resolution: {integrity: sha512-dNaICPvtmuxFP/VbqdofrLqdS3bM/AKJN3LMJD52si44ea7Be1cBk6NpfIahaysG9Uo+L98QKddU9CD5L8UHnQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint/binding-linux-x64-musl@1.56.0':
+    resolution: {integrity: sha512-pF1vOtM+GuXmbklM1hV8WMsn6tCNPvkUzklj/Ej98JhlanbmA2RB1BILgOpwSuCTRTIYx2MXssmEyQQ90QF5aA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint/binding-openharmony-arm64@1.56.0':
+    resolution: {integrity: sha512-bp8NQ4RE6fDIFLa4bdBiOA+TAvkNkg+rslR+AvvjlLTYXLy9/uKAYLQudaQouWihLD/hgkrXIKKzXi5IXOewwg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.56.0':
+    resolution: {integrity: sha512-PxT4OJDfMOQBzo3OlzFb9gkoSD+n8qSBxyVq2wQSZIHFQYGEqIRTo9M0ZStvZm5fdhMqaVYpOnJvH2hUMEDk/g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.56.0':
+    resolution: {integrity: sha512-PTRy6sIEPqy2x8PTP1baBNReN/BNEFmde0L+mYeHmjXE1Vlcc9+I5nsqENsB2yAm5wLkzPoTNCMY/7AnabT4/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.56.0':
+    resolution: {integrity: sha512-ZHa0clocjLmIDr+1LwoWtxRcoYniAvERotvwKUYKhH41NVfl0Y4LNbyQkwMZzwDvKklKGvGZ5+DAG58/Ik47tQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -2228,6 +2462,21 @@ packages:
   oniguruma-to-es@4.3.5:
     resolution: {integrity: sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==}
 
+  oxfmt@0.41.0:
+    resolution: {integrity: sha512-sKLdJZdQ3bw6x9qKiT7+eID4MNEXlDHf5ZacfIircrq6Qwjk0L6t2/JQlZZrVHTXJawK3KaMuBoJnEJPcqCEdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  oxlint@1.56.0:
+    resolution: {integrity: sha512-Q+5Mj5PVaH/R6/fhMMFzw4dT+KPB+kQW4kaL8FOIq7tfhlnEVp6+3lcWqFruuTNlUo9srZUW3qH7Id4pskeR6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.15.0'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
@@ -2583,6 +2832,10 @@ packages:
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
@@ -3273,6 +3526,120 @@ snapshots:
     optional: true
 
   '@orama/orama@3.1.18': {}
+
+  '@oxfmt/binding-android-arm-eabi@0.41.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.41.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.41.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.41.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.41.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.41.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.41.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.41.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.41.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.41.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.41.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.41.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.41.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.41.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.41.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.41.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.41.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.41.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.41.0':
+    optional: true
+
+  '@oxlint/binding-android-arm-eabi@1.56.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.56.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.56.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.56.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.56.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.56.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.56.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.56.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.56.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.56.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.56.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.56.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.56.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.56.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.56.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.56.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.56.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.56.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.56.0':
+    optional: true
 
   '@radix-ui/number@1.1.1': {}
 
@@ -5170,6 +5537,52 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
+  oxfmt@0.41.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.41.0
+      '@oxfmt/binding-android-arm64': 0.41.0
+      '@oxfmt/binding-darwin-arm64': 0.41.0
+      '@oxfmt/binding-darwin-x64': 0.41.0
+      '@oxfmt/binding-freebsd-x64': 0.41.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.41.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.41.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.41.0
+      '@oxfmt/binding-linux-arm64-musl': 0.41.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.41.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.41.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.41.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.41.0
+      '@oxfmt/binding-linux-x64-gnu': 0.41.0
+      '@oxfmt/binding-linux-x64-musl': 0.41.0
+      '@oxfmt/binding-openharmony-arm64': 0.41.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.41.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.41.0
+      '@oxfmt/binding-win32-x64-msvc': 0.41.0
+
+  oxlint@1.56.0:
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.56.0
+      '@oxlint/binding-android-arm64': 1.56.0
+      '@oxlint/binding-darwin-arm64': 1.56.0
+      '@oxlint/binding-darwin-x64': 1.56.0
+      '@oxlint/binding-freebsd-x64': 1.56.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.56.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.56.0
+      '@oxlint/binding-linux-arm64-gnu': 1.56.0
+      '@oxlint/binding-linux-arm64-musl': 1.56.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.56.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.56.0
+      '@oxlint/binding-linux-riscv64-musl': 1.56.0
+      '@oxlint/binding-linux-s390x-gnu': 1.56.0
+      '@oxlint/binding-linux-x64-gnu': 1.56.0
+      '@oxlint/binding-linux-x64-musl': 1.56.0
+      '@oxlint/binding-openharmony-arm64': 1.56.0
+      '@oxlint/binding-win32-arm64-msvc': 1.56.0
+      '@oxlint/binding-win32-ia32-msvc': 1.56.0
+      '@oxlint/binding-win32-x64-msvc': 1.56.0
+
   parse-entities@4.0.2:
     dependencies:
       '@types/unist': 2.0.11
@@ -5612,6 +6025,8 @@ snapshots:
       picomatch: 4.0.3
 
   tinypool@1.1.1: {}
+
+  tinypool@2.1.0: {}
 
   tinyrainbow@2.0.0: {}
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -27,16 +27,28 @@ describe("workspace end to end", () => {
     await runPnpm(["--filter", "@farming-labs/orm", "build"]);
     await runPnpm(["--filter", "@farming-labs/orm-cli", "build"]);
 
-    const prisma = await runNode([cliBin, "generate", "prisma", "-c", "./farm-orm.config.ts"], demoDir);
-    const drizzle = await runNode([cliBin, "generate", "drizzle", "-c", "./farm-orm.config.ts"], demoDir);
+    const prisma = await runNode(
+      [cliBin, "generate", "prisma", "-c", "./farm-orm.config.ts"],
+      demoDir,
+    );
+    const drizzle = await runNode(
+      [cliBin, "generate", "drizzle", "-c", "./farm-orm.config.ts"],
+      demoDir,
+    );
     const sql = await runNode([cliBin, "generate", "sql", "-c", "./farm-orm.config.ts"], demoDir);
 
     expect(prisma.stdout).toContain("Generated prisma output");
     expect(drizzle.stdout).toContain("Generated drizzle output");
     expect(sql.stdout).toContain("Generated sql output");
 
-    const prismaCheck = await runNode([cliBin, "check", "prisma", "-c", "./farm-orm.config.ts"], demoDir);
-    const drizzleCheck = await runNode([cliBin, "check", "drizzle", "-c", "./farm-orm.config.ts"], demoDir);
+    const prismaCheck = await runNode(
+      [cliBin, "check", "prisma", "-c", "./farm-orm.config.ts"],
+      demoDir,
+    );
+    const drizzleCheck = await runNode(
+      [cliBin, "check", "drizzle", "-c", "./farm-orm.config.ts"],
+      demoDir,
+    );
     const sqlCheck = await runNode([cliBin, "check", "sql", "-c", "./farm-orm.config.ts"], demoDir);
 
     expect(prismaCheck.stdout).toContain("up to date");


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add OXC-based linting and formatting to the monorepo, plus new scripts to run lint, format, and type checks. Applied repo-wide formatting with no runtime or CLI behavior changes.

- **Dependencies**
  - Added `oxfmt` and `oxlint` (dev deps) and updated `pnpm-lock.yaml`.
  - Introduced `.oxfmtrc.json` and `.oxlintignore`.

- **Refactors**
  - Added root scripts: `lint`, `lint:fix`, `fmt`, `fmt:check`, and `check` (runs lint, format check, and typecheck).
  - Ran formatter across `apps`, `packages`, and tests: trailing commas, line wrapping, consistent imports, and small doc text tweaks.
  - Minor JSON/TS build script cleanups (e.g., trailing commas, field ordering).

<sup>Written for commit a50796b6e73bd897cad0a7d130e707f524a65b88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

