### PR TITLE
feat: ci for tests and lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint, format & typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm lint
+
+      - run: pnpm fmt:check
+
+      - run: pnpm typecheck
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm test


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a GitHub Actions CI workflow to run lint, format check, typecheck, and tests on pushes and PRs using `pnpm` on Node 22. Cancels in-progress runs to avoid redundant builds.

- **New Features**
  - New `.github/workflows/ci.yml` with two jobs: lint/format/typecheck and test.
  - Triggers on pushes to `main`/`master` and on pull requests.
  - Uses `pnpm install --frozen-lockfile` with cached dependencies.

<sup>Written for commit 1de2462790e69aaa7e015a43cc52239e266b81f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

