### PR TITLE
chore: security ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,14 +57,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
 
       - name: Get pnpm store directory
         shell: bash


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a `security-audit` CI job to scan `pnpm` dependencies and fail on any high or critical vulnerabilities. Also aligns CI to Node 22 with `pnpm` store caching.

- **New Features**
  - Adds `security-audit` job in `.github/workflows/ci.yml` using `actions/checkout@v4`, `pnpm/action-setup@v4`, `actions/setup-node@v4` (Node 22, `cache: pnpm`), and `actions/cache@v4` to cache the `pnpm` store (keyed by `pnpm-lock.yaml`).
  - Installs with `pnpm install --frozen-lockfile`.
  - Runs `pnpm audit --audit-level high` and parses `pnpm audit --json` with `jq` to fail if any high or critical vulnerabilities are found.

<sup>Written for commit c6e95a48bc0b6b63ab24c5697e394258d798fa9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

