### PR TITLE
feat: mcp config

### DIFF
--- a/apps/docs/docs.config.tsx
+++ b/apps/docs/docs.config.tsx
@@ -163,13 +163,16 @@ export default defineDocs({
       },
     },
   }),
-  // mcp: {
-  //   enabled: true,
-  // },
-  // search: {
-  //   provider: "mcp",
-  //   endpoint: "/api/docs/mcp"
-  // },
+  mcp: {
+    enabled: true,
+    name: "@farming-labs/orm",
+    tools: {
+      listPages: true,
+      readPage: true,
+      searchDocs: true,
+      getNavigation: true,
+    },
+  },
   nav: {
     title: (
       <div className="flex items-center gap-3 font-medium tracking-tight text-white">

--- a/apps/docs/next-env.d.ts
+++ b/apps/docs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable MCP in the docs and expose tools so clients can list, read, search, and navigate pages. Also fix the Next.js types import path to work outside dev builds.

- **New Features**
  - Turn on `mcp` in `apps/docs/docs.config.tsx` with name `@farming-labs/orm` and tools: `listPages`, `readPage`, `searchDocs`, `getNavigation`.

- **Bug Fixes**
  - Update types import to `./.next/types/routes.d.ts` in `next-env.d.ts` to replace the dev-only path.

<sup>Written for commit f015bccfd5c58e20e0c8e10f4c67b0c22f04ca62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

