### PR TITLE
chore: security ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
       "defu": "^6.1.6",
       "@tootallnate/once": "^3.0.1",
       "lodash": "^4.18.1",
+      "protobufjs": "^7.5.5",
       "vite": "^7.3.2",
       "picomatch": "^4.0.4",
       "path-to-regexp": "^8.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   defu: ^6.1.6
   '@tootallnate/once': ^3.0.1
   lodash: ^4.18.1
+  protobufjs: ^7.5.5
   vite: ^7.3.2
   picomatch: ^4.0.4
   path-to-regexp: ^8.4.0
@@ -4872,8 +4873,8 @@ packages:
     resolution: {integrity: sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==}
     engines: {node: '>=14.0.0'}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -6621,7 +6622,7 @@ snapshots:
       fast-deep-equal: 3.1.3
       functional-red-black-tree: 1.0.1
       google-gax: 4.6.1
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -6635,14 +6636,14 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
       yargs: 17.7.2
 
   '@grpc/proto-loader@0.8.0':
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
       yargs: 17.7.2
 
   '@hono/node-server@1.19.13(hono@4.12.14)':
@@ -9208,7 +9209,7 @@ snapshots:
       node-fetch: 2.7.0
       object-hash: 3.0.0
       proto3-json-serializer: 2.0.2
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
       retry-request: 7.0.2
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -10627,9 +10628,9 @@ snapshots:
 
   proto3-json-serializer@2.0.2:
     dependencies:
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
 
-  protobufjs@7.5.4:
+  protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `protobufjs` as a direct dependency and pin it to `^7.5.5` to satisfy security CI and unify the version across transitive consumers.

- **Dependencies**
  - Add `protobufjs@^7.5.5` to `package.json`.
  - Update `pnpm-lock.yaml` to prefer `7.5.5` (replacing `7.5.4` in transitive deps).

<sup>Written for commit f528e58200b20e31c01bf492f5972a9d364b1df5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

